### PR TITLE
Check to see if ezproxy is enabled before proxying resources with it.

### DIFF
--- a/templates/views-ezproxy_url.inc
+++ b/templates/views-ezproxy_url.inc
@@ -1,41 +1,37 @@
 <?php
-    $db_url =""; // proxied link to url with ou proxy
+$db_url =""; // proxied link to url with ou proxy
 
-	$proxy="";
-	$access_class="access_open";
-	
-	try {
-		// See if this resource is set to be proxied
-		$proxy_arr = $view->style_plugin->get_field_value($key, "field_proxy");
-		$proxy = $proxy_arr[0]["value"];
-		
-		
-	} catch ( Exception $e) {
-	    watchdog('ezproxy template error','view missing proxy field when trying to do ezy proxy display');
-	}
+$proxy="";
+$access_class="access_open";
 
+try {
+  // See if this resource is set to be proxied
+  $proxy_arr = $view->style_plugin->get_field_value($key, "field_proxy");
+  $proxy = $proxy_arr[0]["value"];
 
+} catch ( Exception $e) {
+  watchdog('ezproxy template error','view missing proxy field when trying to do ezy proxy display');
+}
 
-    // If so, get the configuration from the ezproxy module and set the URL prefix
-    if ($proxy == 1) {
-	  $access_class="access_closed";
-      $proxy_host = variable_get('ezproxy_host', 'http://ezproxy.example.com');
-      $proxy_port = variable_get('ezproxy_port', '2048');
-      // Don't specifiy port if it's standard http/https
-      if (($proxy_port == '80') || ($proxy_port == '443') || !(is_numeric($proxy_port)) ) {
-        $proxy_port = NULL;
-      // Otherwise set the string to :port
-      } else {
-        $proxy_port = ':' . $proxy_port;
-      }
+// If the resource should be proxied and proxying is enabled, get the
+// configuration from the ezproxy module and set the URL prefix
+if ($proxy == 1 && module_exists("ezproxy") ) {
+  $access_class="access_closed";
+  $proxy_host = variable_get('ezproxy_host', 'http://ezproxy.example.com');
+  $proxy_port = variable_get('ezproxy_port', '2048');
+  // Don't specifiy port if it's standard http/https
+  if (($proxy_port == '80') || ($proxy_port == '443') || !(is_numeric($proxy_port)) ) {
+    $proxy_port = NULL;
+    // Otherwise set the string to :port
+  } else {
+    $proxy_port = ':' . $proxy_port;
+  }
 
-      // Set the prefix and add it the url
-      $proxy_prefix = "$proxy_host" . "$proxy_port" . '/login?url=';
-      $db_url = $proxy_prefix . $view->style_plugin->get_field($key, "field_link");
+  // Set the prefix and add it the url
+  $proxy_prefix = "$proxy_host" . "$proxy_port" . '/login?url=';
+  $db_url = $proxy_prefix . $view->style_plugin->get_field($key, "field_link");
 
-
-    // If the resource isn't set to be proxied, kill the prefix and do the bare url
-    } else {
-        $db_url = $view->style_plugin->get_field($key, "field_link");
-    }
- ?>
+  // If the resource isn't set to be proxied, kill the prefix and do the bare url
+} else {
+  $db_url = $view->style_plugin->get_field($key, "field_link");
+}


### PR DESCRIPTION
Add a `module_exists()` check for the `ezproxy` module before decorating proxied URIs to send them through ezproxy. 

Motivation and Context
----------------------
We need a simple way to disable proxying via ezproxy and this makes it conditional on the state of the installed module. 

How Has This Been Tested?
-------------------------
Works to toggle proxying based on ezproxy module status in local dev. 
